### PR TITLE
List of SPARQL 1.2 documents

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>Spec proposal</title>
+    <title>SPARQL 1.2</title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
     <script class='remove'>
       // See https://github.com/w3c/respec/wiki/ for how to configure ReSpec
@@ -10,11 +10,11 @@
         specStatus: "DNOTE",
         shortName: "sparql12-new",
         editors: [{
-          name: "Pierre-Antoine Champin"
+          name: "RDF Star WG"
         }],
 
         github: "https://github.com/w3c/sparql-new/",
-        group:           "rdf-star",
+        group:        "rdf-star",
         doJsonLd:     true,
         wgPublicList: "public-rdf-star-wg"
       };
@@ -35,9 +35,27 @@
     <section id="introduction">
       <h2>Introduction</h2>
       <p>
-        See <a href="https://github.com/w3c/respec/wiki/User's-Guide">ReSpec's user guide</a>
-        for how toget started!
+        text
       </p>
     </section>
+
+    <section id="sparql12-documents">
+      <h2>SPARQL 1.2 Documents</h2>
+        <ul>
+          <li><a href="../../sparql-new/spec/index.html">SPARQL 1.2 New</a></li>
+          <li><a href="../../sparql-concepts/spec/index.html">SPARQL 1.2 Overview</a></li>
+          <li><a href="../../sparql-query/spec/index.html">SPARQL 1.2 Query Language</a></li>
+          <li><a href="../../sparql-update/spec/index.html">SPARQL 1.2 Update</a></li>
+          <li><a href="../../sparql-entailment/spec/index.html">SPARQL 1.2 Entailment Regimes</a></li>
+          <li><a href="../../sparql-service-description/spec/index.html">SPARQL 1.2 Service Description</a></li>
+          <li><a href="../../sparql-federated-query/spec/index.html">SPARQL 1.2 Federated Query</a></li>
+          <li><a href="../../sparql-results-json/spec/index.html">SPARQL 1.2 Query Results JSON Format</a></li>
+          <li><a href="../../sparql-results-csv-tsv/spec/index.html">SPARQL 1.2 Query Results CSV and TSV Formats</a></li>
+          <li><a href="../../sparql-results-xml/spec/index.html">SPARQL 1.2 Query Results XML Format</a></li>
+          <li><a href="../../sparql-graph-store-protocol/spec/index.html">SPARQL 1.2 Graph Store Protocol</a></li>
+          <li><a href="../../sparql-protocol/spec/index.html">SPARQL 1.2 Protocol</a></li>
+        </ul>
+    </section>
+
   </body>
 </html>


### PR DESCRIPTION
Put navigation links into "SPARQL 1.2. New".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 522  :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jan 21, 2023, 4:48 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fsparql-new%2Fdb367994e1e325c5433b830b03d804d512964c61%2Fspec%2Findex.html%3FisPreview%3Dtrue)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/sparql-new%232.)._
</details>
