### PR TITLE
Fix intro section nesting

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -41,9 +41,9 @@
       <p>
         text
       </p>
-    </section>
 
-    <section id="related" data-include="common/sparql-related.html"></section>
+      <section id="related" data-include="common/sparql-related.html"></section>
+    </section>
 
   </body>
 </html>


### PR DESCRIPTION
The "Set of documents" is appearing a "section 1", after the unnumbered "Status of the Document". It should be unnumbered and a subsection of "Status". This does not show in the preview.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-new/pull/14.html" title="Last updated on Nov 9, 2024, 2:32 PM UTC (3cd12ff)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-new/14/870b276...3cd12ff.html" title="Last updated on Nov 9, 2024, 2:32 PM UTC (3cd12ff)">Diff</a>